### PR TITLE
More efficient numpy implementation for zero suppression

### DIFF
--- a/examples/waveforms/zero_suppression/impl.py
+++ b/examples/waveforms/zero_suppression/impl.py
@@ -14,10 +14,8 @@ def input_generator():
 import numpy as np
 
 def numpy_zero_suppression(values, threshold):
-    result = np.zeros_like(values)
-    selector = np.abs(values) >= threshold
-    result[selector] = values[selector]
-    return result
+    cond = np.less(np.absolute(values), threshold)
+    return np.where(cond, 0, values)
 #### END: numpy
 
 #### BEGIN: numba_single_thread_ufunc


### PR DESCRIPTION
This PR provides a more efficient NumPy implementation is based on how hard thresholding is currently implemented in `PyWavelets`.  On my machine it is about two times faster than the pervious numpy implementation.

Numba still comes out ahead (speedup factor 2.8 for float64 on my machine).
