### PR TITLE
Add example calling cuRAND

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,6 @@ ENV/
 
 # mypy
 .mypy_cache/
+
+# Vim swap files
+.*.swp

--- a/examples/cuda/curand/example.py
+++ b/examples/cuda/curand/example.py
@@ -29,7 +29,7 @@ repetitions = 50
 @cuda.jit(link=['shim.cu'], extensions=[curand_state_arg_handler])
 def setup(states):
     i = cuda.grid(1)
-    curand_init(1234, i, 0, states[i])
+    curand_init(1234, i, 0, states, i)
 
 
 # Random sampling kernel - computes the fraction of numbers with low bits set
@@ -40,19 +40,19 @@ def count_low_bits_native(states, sample_count, results):
     i = cuda.grid(1)
     count = 0
 
-    # This thread's state
-    localState = states[i]
+    # Copy state to local memory
+    # XXX: TBC
 
     # Generate pseudo-random numbers
     for sample in range(sample_count):
-        x = curand(localState)
+        x = curand(states, i)
 
         # Check if low bit set
         if(x & 1):
             count += 1
 
     # Copy state back to global memory
-    states[i] = localState
+    # XXX: TBC
 
     # Store results
     results[i] += count

--- a/examples/cuda/curand/example.py
+++ b/examples/cuda/curand/example.py
@@ -8,6 +8,10 @@
 #
 # Output from this example:                  0.4999931156635
 # Output from cuRAND documentation example:  0.4999931156635
+#
+# Note that this example requires an installation of the CUDA toolkit 11.0 or
+# later, because NVRTC will use the include files from the installed CUDA
+# toolkit.
 
 import sys
 

--- a/examples/cuda/curand/example.py
+++ b/examples/cuda/curand/example.py
@@ -1,0 +1,94 @@
+# Demonstration of calling cuRAND functions from Numba kernels. Shim functions
+# in a .cu file are used to access the cuRAND functions from Numba. This is
+# based on the cuRAND device API example in:
+# https://docs.nvidia.com/cuda/curand/device-api-overview.html#device-api-example
+#
+# The result produced by this example agrees with the documentation example.
+# E.g. on a particular configuration:
+#
+# Output from this example:                  0.4999931156635
+# Output from cuRAND documentation example:  0.4999931156635
+
+from numba import cuda
+import numpy as np
+
+# Various parameters
+
+threads = 64
+blocks = 64
+nthreads = blocks * threads
+
+sample_count = 10000
+repetitions = 50
+
+
+# cuRAND state type - mirrors the state defined in curand_kernel.h
+state_fields = [
+    ('d', np.int32),
+    ('v', np.int32, 5),
+    ('boxmuller_flag', np.int32),
+    ('boxmuller_flag_double', np.int32),
+    ('boxmuller_extra', np.float32),
+    ('boxmuller_extra_double', np.float64),
+]
+
+curandState = np.dtype(state_fields, align=True)
+
+
+# Forward declarations of shim functions in the .cu source
+
+init_states = cuda.declare_device('init_states', 'void(uint64)')
+generate_results = cuda.declare_device(
+    'generate_results', 'int32(uint64, int32)')
+
+
+# Kernels that call shim functions. Shim functions take a pointer to the data
+# rather than a Numba array type.
+
+@cuda.jit(link=['shim.cu'])
+def setup_curand(states_ptr):
+    init_states(states_ptr)
+
+
+@cuda.jit(link=['shim.cu'])
+def count_low_bits(states_ptr, sample_count, results):
+    i = cuda.grid(1)
+    results[i] += generate_results(states_ptr, sample_count)
+
+
+# Create state on the device. The CUDA Array Interface provides a convenient
+# way to get the pointer needed for the shim functions.
+
+state = cuda.device_array(nthreads, dtype=curandState)
+states_ptr = state.__cuda_array_interface__['data'][0]
+
+results = cuda.to_device(np.zeros(nthreads, dtype=np.int32))
+
+
+# Initialise cuRAND state
+
+setup_curand[blocks, threads](states_ptr)
+
+
+# Run random sampling kernel
+
+for i in range(repetitions):
+    count_low_bits[blocks, threads](states_ptr, sample_count, results)
+
+
+# Collect the results and summarize them. This could have been done on device,
+# but the corresponding CUDA C++ sample does it on the host, and we're
+# following that example.
+
+host_results = results.copy_to_host()
+
+total = 0
+for i in range(nthreads):
+    total += host_results[i]
+
+# Use float32 to show an exact match between this and the cuRAND documentation
+# example
+fraction = (np.float32(total) /
+            np.float32(nthreads * sample_count * repetitions))
+
+print(f"Fraction with low bit set was {fraction:17.13f}")

--- a/examples/cuda/curand/example.py
+++ b/examples/cuda/curand/example.py
@@ -9,6 +9,18 @@
 # Output from this example:                  0.4999931156635
 # Output from cuRAND documentation example:  0.4999931156635
 
+import sys
+
+try:
+    from cuda import cuda as cuda_driver  # noqa: F401
+    from numba import config
+    config.CUDA_USE_NVIDIA_BINDING = True
+except ImportError:
+    print("This example requires the NVIDIA CUDA Python Bindings. "
+          "Please see https://nvidia.github.io/cuda-python/install.html for "
+          "installation instructions.")
+    sys.exit(1)
+
 from numba import cuda
 from numba_curand import (curand_init, curand, curand_state_arg_handler,
                           CurandStates)

--- a/examples/cuda/curand/numba_curand.py
+++ b/examples/cuda/curand/numba_curand.py
@@ -1,0 +1,171 @@
+# Numba extension for cuRAND functions. Presently only implements:
+#
+# - curand_init()
+# - curand()
+#
+# This is enough for a proof-of-concept embedded calls to cuRAND functions in
+# Numba kernels.
+
+from numba import cuda, types
+from numba.core.extending import (lower_builtin, models, register_model,
+                                  typeof_impl)
+from numba.core.typing.templates import AbstractTemplate, signature
+from numba.cuda.cudadecl import register_global
+
+import numpy as np
+import operator
+
+
+# cuRAND state type as a NumPy dtype - this mirrors the state defined in
+# curand_kernel.h. Can be used to inspect the state through the device array
+# held by CurandStates.
+
+state_fields = [
+    ('d', np.int32),
+    ('v', np.int32, 5),
+    ('boxmuller_flag', np.int32),
+    ('boxmuller_flag_double', np.int32),
+    ('boxmuller_extra', np.float32),
+    ('boxmuller_extra_double', np.float64),
+]
+
+curandState = np.dtype(state_fields, align=True)
+
+
+# Hold an array of cuRAND states - somewhat analagous to a curandState* in
+# C/C++.
+
+class CurandStates:
+    def __init__(self, n):
+        self._array = cuda.device_array(n, dtype=curandState)
+
+    @property
+    def data(self):
+        return self._array.__cuda_array_interface__['data'][0]
+
+
+# Numba typing for cuRAND state. Generally we treat cuRAND states as a struct
+# mirroring the C/C++ struct, and an array of states is a pointer with slightly
+# special behaviour - doing a getitem on a state array returns a reference
+# (pointer) to that element, because we need to pass pointers to individual
+# elements to cuRAND functions.
+
+class CurandState(types.Type):
+    def __init__(self):
+        super().__init__(name='CurandState')
+
+
+curand_state = CurandState()
+
+
+class CurandStatePointer(types.Type):
+    def __init__(self):
+        self.dtype = curand_state
+        super().__init__(name='CurandState*')
+
+
+curand_state_pointer = CurandStatePointer()
+
+
+@typeof_impl.register(CurandStates)
+def typeof_curand_states(val, c):
+    return curand_state_pointer
+
+
+# The CurandState model mirrors the C/C++ structure, and the state pointer
+# represented similarly to other pointers.
+
+@register_model(CurandState)
+class curand_state_model(models.StructModel):
+    def __init__(self, dmm, fe_type):
+        members = [
+            ('d', types.int32),
+            ('v', types.UniTuple(types.int32, 5)),
+            ('boxmuller_flag', types.int32),
+            ('boxmuller_flag_double', types.int32),
+            ('boxmuller_extra', types.float32),
+            ('boxmuller_extra_double', types.float64),
+        ]
+        super().__init__(dmm, fe_type, members)
+
+
+register_model(CurandStatePointer)(models.PointerModel)
+
+
+# Typing for cuRAND states:
+#
+# - getitem on a CurandStatePointer returns another CurandStatePointer.
+# - setitem on a CurandStatePointer with a CurandState copies the CurandState
+#   to the item referred to by the index.
+
+@register_global(operator.getitem)
+class GetItemCurandStatePointer(AbstractTemplate):
+    def generic(self, args, kws):
+        assert not kws
+        ptr, idx = args
+        if (isinstance(ptr, CurandStatePointer) and
+                isinstance(idx, types.Integer)):
+            i = types.intp if idx.signed else types.uintp
+            return signature(ptr, ptr, i)
+
+
+@register_global(operator.setitem)
+class SetItemCurandStatePointer(AbstractTemplate):
+    def generic(self, args, kws):
+        assert not kws
+        ptr, idx, val = args
+        if (isinstance(ptr, CurandStatePointer) and
+                isinstance(idx, types.Integer) and
+                isinstance(val, CurandStatePointer)):
+            i = types.intp if idx.signed else types.uintp
+            return signature(types.none, ptr, i, val)
+
+
+# Lowering for cuRAND states, following the rules outlined above.
+
+@lower_builtin(operator.getitem, CurandStatePointer, types.Integer)
+def getitem_curand_states(context, builder, sig, args):
+    base_ptr, idx = args
+    elem_ptr = builder.gep(base_ptr, [idx])
+    return elem_ptr
+
+
+@lower_builtin(operator.setitem, CurandStatePointer, types.Integer,
+               CurandStatePointer)
+def setitem_curand_states(context, builder, sig, args):
+    base_ptr, idx, val = args
+    elem_ptr = builder.gep(base_ptr, [idx])
+    builder.store(builder.load(val), elem_ptr)
+
+
+# Numba forward declarations of cuRAND functions. These call shim functions
+# prepended with _numba, that simply forward arguments to the named cuRAND
+# function.
+
+curand_init_sig = types.void(
+    types.uint64,
+    types.uint64,
+    types.uint64,
+    curand_state_pointer
+)
+
+curand_init = cuda.declare_device('_numba_curand_init', curand_init_sig)
+curand = cuda.declare_device('_numba_curand',
+                             types.uint32(curand_state_pointer))
+
+
+# Argument handling. When a CurandStatePointer is passed into a kernel, we
+# really only need to pass the pointer to the data, not the whole underlying
+# array structure. Our handler here transforms these arguments into a uint64
+# holding the pointer.
+
+class CurandStateArgHandler:
+    def prepare_args(self, ty, val, **kwargs):
+        if isinstance(val, CurandStates):
+            assert ty == curand_state_pointer
+            return types.uint64, val.data
+        else:
+            return ty, val
+
+
+curand_state_arg_handler = CurandStateArgHandler()

--- a/examples/cuda/curand/shim.cu
+++ b/examples/cuda/curand/shim.cu
@@ -6,46 +6,30 @@
 //   during function execution. This does not happen in C/C++ kernels, so we
 //   always return 0.
 // - The result returned to Numba is passed as a pointer in the first parameter.
-//   For void functions (such as init_states()), a parameter is passed, but is
+//   For void functions (such as curand_init()), a parameter is passed, but is
 //   unused.
 
 #include <curand_kernel.h>
 
 extern "C"
-__device__ int init_states(int* return_value, curandState *state)
+__device__ int _numba_curand_init(
+    int* numba_return_value,
+    unsigned long long seed,
+    unsigned long long sequence,
+    unsigned long long offset,
+    curandState *state)
 {
-    int id = threadIdx.x + blockIdx.x * blockDim.x;
-    curand_init(1234, id, 0, &state[id]);
+    curand_init(seed, sequence, offset, state);
 
-    // Indicate that no exception occurred
     return 0;
 }
 
 extern "C"
-__device__ int generate_results(unsigned int* result, curandState *state, int n)
+__device__ unsigned int _numba_curand(
+    int* numba_return_value,
+    curandState *state)
 {
-    int id = threadIdx.x + blockIdx.x * blockDim.x;
-    int count = 0;
-    unsigned int x;
+  *numba_return_value = curand(state);
 
-    // Copy state to local memory for efficiency
-    curandState localState = state[id];
-
-    // Generate pseudo-random unsigned ints
-    for(int i = 0; i < n; i++) {
-        x = curand(&localState);
-
-        // Check if low bit set
-        if(x & 1) {
-            count++;
-        }
-    }
-    // Copy state back to global memory
-    state[id] = localState;
-
-    // Store results
-    *result = count;
-
-    // Indicate that no exception occurred
-    return 0;
+  return 0;
 }

--- a/examples/cuda/curand/shim.cu
+++ b/examples/cuda/curand/shim.cu
@@ -17,9 +17,10 @@ __device__ int _numba_curand_init(
     unsigned long long seed,
     unsigned long long sequence,
     unsigned long long offset,
-    curandState *state)
+    curandState *state,
+    unsigned long long index)
 {
-    curand_init(seed, sequence, offset, state);
+    curand_init(seed, sequence, offset, &state[index]);
 
     return 0;
 }
@@ -27,9 +28,10 @@ __device__ int _numba_curand_init(
 extern "C"
 __device__ unsigned int _numba_curand(
     int* numba_return_value,
-    curandState *state)
+    curandState *states,
+    unsigned long long index)
 {
-  *numba_return_value = curand(state);
+  *numba_return_value = curand(&states[index]);
 
   return 0;
 }

--- a/examples/cuda/curand/shim.cu
+++ b/examples/cuda/curand/shim.cu
@@ -1,0 +1,51 @@
+// Shim functions for calling cuRAND from Numba functions.
+//
+// Numba's ABI expects that:
+//
+// - The return value is used to indicate whether a Python exception occurred
+//   during function execution. This does not happen in C/C++ kernels, so we
+//   always return 0.
+// - The result returned to Numba is passed as a pointer in the first parameter.
+//   For void functions (such as init_states()), a parameter is passed, but is
+//   unused.
+
+#include <curand_kernel.h>
+
+extern "C"
+__device__ int init_states(int* return_value, curandState *state)
+{
+    int id = threadIdx.x + blockIdx.x * blockDim.x;
+    curand_init(1234, id, 0, &state[id]);
+
+    // Indicate that no exception occurred
+    return 0;
+}
+
+extern "C"
+__device__ int generate_results(unsigned int* result, curandState *state, int n)
+{
+    int id = threadIdx.x + blockIdx.x * blockDim.x;
+    int count = 0;
+    unsigned int x;
+
+    // Copy state to local memory for efficiency
+    curandState localState = state[id];
+
+    // Generate pseudo-random unsigned ints
+    for(int i = 0; i < n; i++) {
+        x = curand(&localState);
+
+        // Check if low bit set
+        if(x & 1) {
+            count++;
+        }
+    }
+    // Copy state back to global memory
+    state[id] = localState;
+
+    // Store results
+    *result = count;
+
+    // Indicate that no exception occurred
+    return 0;
+}


### PR DESCRIPTION
This is an example based on the [cuRAND device API example](https://docs.nvidia.com/cuda/curand/device-api-overview.html#device-api-example) from the [cuRAND documentation](https://docs.nvidia.com/cuda/curand/index.html).

This requires numba/numba#7621